### PR TITLE
fix: 修改数据库中candles数据的时间戳为unix时间戳

### DIFF
--- a/pkg/binance/get_candlestick_data.go
+++ b/pkg/binance/get_candlestick_data.go
@@ -28,13 +28,13 @@ func GetCandlestickData(query datamodel.ApiCandlesQuery) ([]datamodel.ApiCandles
 	var candles []datamodel.ApiCandlesResponse
 	for _, rawCandle := range rawCandles {
 		candle := datamodel.ApiCandlesResponse{
-			OpenTime:                 int64(rawCandle[0].(float64)),
+			OpenTime:                 uint64(rawCandle[0].(float64)),
 			Open:                     rawCandle[1].(string),
 			High:                     rawCandle[2].(string),
 			Low:                      rawCandle[3].(string),
 			Close:                    rawCandle[4].(string),
 			Volume:                   rawCandle[5].(string),
-			CloseTime:                int64(rawCandle[6].(float64)),
+			CloseTime:                uint64(rawCandle[6].(float64)),
 			QuoteAssetVolume:         rawCandle[7].(string),
 			NumberOfTrades:           int64(rawCandle[8].(float64)),
 			TakerBuyBaseAssetVolume:  rawCandle[9].(string),

--- a/pkg/convert/body2db/candles.go
+++ b/pkg/convert/body2db/candles.go
@@ -12,8 +12,8 @@ func CandlesBody2DB(exchange string, query datamodel.ApiCandlesQuery, candles []
 			Exchange:       exchange,
 			Symbol:         query.Symbol,
 			Interval:       query.Interval,
-			OpenTime:       utils.Unix2Time(candle.OpenTime),
-			EndTime:        utils.Unix2Time(candle.CloseTime),
+			OpenTime:       candle.OpenTime,
+			EndTime:        candle.CloseTime,
 			Open:           utils.StringToFloat64(candle.Open),
 			High:           utils.StringToFloat64(candle.High),
 			Low:            utils.StringToFloat64(candle.Low),
@@ -23,6 +23,7 @@ func CandlesBody2DB(exchange string, query datamodel.ApiCandlesQuery, candles []
 			Trades:         uint64(candle.NumberOfTrades),
 			BuyVolume:      utils.StringToFloat64(candle.TakerBuyBaseAssetVolume),
 			BuyQuoteVolume: utils.StringToFloat64(candle.TakerBuyQuoteAssetVolume),
+			TimeStamp:      utils.Unix2Time(int64(candle.OpenTime)),
 		}
 	}
 	return dbCandles

--- a/pkg/datamodel/api_candles_api.go
+++ b/pkg/datamodel/api_candles_api.go
@@ -9,13 +9,13 @@ type ApiCandlesQuery struct {
 }
 
 type ApiCandlesResponse struct {
-	OpenTime                 int64  `json:"openTime"`                 // 开盘时间
+	OpenTime                 uint64 `json:"openTime"`                 // 开盘时间
 	Open                     string `json:"open"`                     // 开盘价
 	High                     string `json:"high"`                     // 最高价
 	Low                      string `json:"low"`                      // 最低价
 	Close                    string `json:"close"`                    // 收盘价
 	Volume                   string `json:"volume"`                   // 成交量
-	CloseTime                int64  `json:"closeTime"`                // 收盘时间
+	CloseTime                uint64 `json:"closeTime"`                // 收盘时间
 	QuoteAssetVolume         string `json:"quoteAssetVolume"`         // 报价资产成交量
 	NumberOfTrades           int64  `json:"numberOfTrades"`           // 交易次数
 	TakerBuyBaseAssetVolume  string `json:"takerBuyBaseAssetVolume"`  // 买入成交量

--- a/pkg/datamodel/db_candles.go
+++ b/pkg/datamodel/db_candles.go
@@ -6,8 +6,8 @@ type CandleDBModel struct {
 	Exchange       string    // 交易所名称（如 binance）
 	Symbol         string    // 币对（如 BTC/USDT）
 	Interval       string    // K线周期（如 1m, 5m）
-	OpenTime       time.Time // 开始时间，使用 Unix 时间戳
-	EndTime        time.Time // 结束时间，使用 Unix 时间戳
+	OpenTime       uint64    // 开始时间，使用 Unix 时间戳
+	EndTime        uint64    // 结束时间，使用 Unix 时间戳
 	Open           float64   // 开盘价
 	High           float64   // 最高价
 	Low            float64   // 最低价
@@ -17,4 +17,5 @@ type CandleDBModel struct {
 	Trades         uint64    // 成交笔数
 	BuyVolume      float64   // 主动买入量
 	BuyQuoteVolume float64   // 主动买入额
+	TimeStamp      time.Time // 时间戳
 }

--- a/pkg/tradingdb/writer/candles.go
+++ b/pkg/tradingdb/writer/candles.go
@@ -13,8 +13,8 @@ func WriteCandles(db *sql.DB, candles []datamodel.CandleDBModel) error {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(
-		"INSERT INTO candles (exchange, symbol, interval, open_time, end_time, open, high, low, close, volume, quote_volume, trades, buy_volume, buy_quote_volume) " +
-			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO candles (exchange, symbol, interval, open_time, end_time, open, high, low, close, volume, quote_volume, trades, buy_volume, buy_quote_volume, timestamp) " +
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 	)
 	if err != nil {
 		return err
@@ -26,6 +26,7 @@ func WriteCandles(db *sql.DB, candles []datamodel.CandleDBModel) error {
 			candle.Exchange, candle.Symbol, candle.Interval, candle.OpenTime, candle.EndTime,
 			candle.Open, candle.High, candle.Low, candle.Close, candle.Volume,
 			candle.QuoteVolume, candle.Trades, candle.BuyVolume, candle.BuyQuoteVolume,
+			candle.TimeStamp,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
2 fix修改数据库中candles数据的open_time和end_time的时间戳为unix时间戳
增加timestamp用于clickhouse分区，其值等于open_time，数据格式为Datetime格式